### PR TITLE
Switch local dev from HTTPS to plain HTTP with localhost

### DIFF
--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -14,8 +14,8 @@ const Env = Record({
 const getNonSecretKeys = () => {
   if (process.env.NODE_ENV !== 'production') {
     return {
-      frontendUrl: 'http://127.0.0.1:3000',
-      spotifyRedirectURI: 'https://127.0.0.1:8000/spotify_redirect',
+      frontendUrl: 'http://localhost:3000',
+      spotifyRedirectURI: 'http://127.0.0.1:8000/spotify_redirect',
     }
   }
   return {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,6 +1,3 @@
-import fs from 'node:fs'
-import https from 'node:https'
-import path from 'node:path'
 import * as Sentry from '@sentry/node'
 import cors from 'cors'
 import express from 'express'
@@ -60,24 +57,9 @@ Sentry.setupExpressErrorHandler(app)
 
 const PORT = 8000
 
-let server: https.Server | import('http').Server
-if (config.isProd) {
-  server = app.listen(PORT, '0.0.0.0', () => {
-    console.log(`App listening at http://0.0.0.0:${PORT}`)
-  })
-} else {
-  server = https.createServer(
-    {
-      key: fs.readFileSync(path.join(__dirname, '/../localhost-key.pem')),
-      cert: fs.readFileSync(path.join(__dirname, '/../localhost.pem')),
-    },
-    app,
-  )
-
-  server.listen(PORT, '0.0.0.0', () => {
-    console.log(`App listening at https://127.0.0.1:${PORT}`)
-  })
-}
+const server = app.listen(PORT, '0.0.0.0', () => {
+  console.log(`App listening at http://localhost:${PORT}`)
+})
 
 const wsServer = new WebSocketServer({ server, path: '/graphql' })
 useServer({ schema }, wsServer)

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,8 +4,8 @@ import path from 'path'
 
 const envVars = {
   local: {
-    __API_WS_ENDPOINT__: JSON.stringify('wss://127.0.0.1:8000/graphql'),
-    __API_HTTP_ENDPOINT__: JSON.stringify('https://127.0.0.1:8000/graphql'),
+    __API_WS_ENDPOINT__: JSON.stringify('ws://localhost:8000/graphql'),
+    __API_HTTP_ENDPOINT__: JSON.stringify('http://localhost:8000/graphql'),
     __LOGGING_LEVEL__: JSON.stringify('local'),
   },
   production: {


### PR DESCRIPTION
## Summary
- Remove HTTPS server with self-signed certs for local dev, use plain HTTP
- Switch frontend URL and API endpoints to `http://localhost`
- Keep Spotify redirect URI as `http://127.0.0.1:8000` (Spotify allows http only for loopback IPs)
- Fixes Vite 7 rejecting requests to `127.0.0.1` with `{"error":"Unauthorized"}`

## Manual step
Update Spotify Developer Dashboard redirect URI to `http://127.0.0.1:8000/spotify_redirect`

🤖 Generated with [Claude Code](https://claude.com/claude-code)